### PR TITLE
Remove Trailing `?` in URL

### DIFF
--- a/dune_client/query.py
+++ b/dune_client/query.py
@@ -27,5 +27,9 @@ class Query:
     def url(self) -> str:
         """Returns a parameterized link to the query"""
         # Include variable parameters in the URL so they are set
-        query = "&".join([f"{p.key}={p.value}" for p in self.parameters()])
-        return "?".join([self.base_url(), urllib.parse.quote_plus(query, safe="=&?")])
+        params = "&".join([f"{p.key}={p.value}" for p in self.parameters()])
+        if params:
+            return "?".join(
+                [self.base_url(), urllib.parse.quote_plus(params, safe="=&?")]
+            )
+        return self.base_url()

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -24,7 +24,7 @@ class TestQueryMonitor(unittest.TestCase):
             self.query.url(),
             "https://dune.com/queries/0?Enum=option1&Text=plain+text&Number=12&Date=2021-01-01+12%3A34%3A56",
         )
-
+        self.assertEqual(Query("", 0, []).url(), "https://dune.com/queries/0")
     def test_parameters(self):
         self.assertEqual(self.query.parameters(), self.query_params)
 

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -25,6 +25,7 @@ class TestQueryMonitor(unittest.TestCase):
             "https://dune.com/queries/0?Enum=option1&Text=plain+text&Number=12&Date=2021-01-01+12%3A34%3A56",
         )
         self.assertEqual(Query("", 0, []).url(), "https://dune.com/queries/0")
+
     def test_parameters(self):
         self.assertEqual(self.query.parameters(), self.query_params)
 


### PR DESCRIPTION
When a query has empty parameters, the url was leaving a trailing ?. This doesn't affect performance, so this is not an urgent change.