### PR TITLE
Update models.py with a few more fields

### DIFF
--- a/dune_client/client.py
+++ b/dune_client/client.py
@@ -125,4 +125,8 @@ class DuneClient(DuneInterface):
             log.info(f"waiting for query execution {job_id} to complete")
             time.sleep(ping_frequency)
 
-        return self.get_result(job_id).result.rows
+        full_response = self.get_result(job_id)
+        assert (
+            full_response.result is not None
+        ), f"Expected Results on completed execution status {full_response}"
+        return full_response.result.rows

--- a/dune_client/models.py
+++ b/dune_client/models.py
@@ -93,9 +93,9 @@ class ExecutionStatusResponse:
     result_metadata: Optional[ResultMetadata]
 
     @classmethod
-    def from_dict(cls, data: dict[str, str]) -> ExecutionStatusResponse:
+    def from_dict(cls, data: dict[str, Any]) -> ExecutionStatusResponse:
         """Constructor from dictionary. See unit test for sample input."""
-        dct = data.get("result_metadata")
+        dct: Optional[MetaData] = data.get("result_metadata")
         result_metadata = ResultMetadata.from_dict(dct) if dct else None
         return cls(
             execution_id=data["execution_id"],

--- a/dune_client/models.py
+++ b/dune_client/models.py
@@ -63,17 +63,19 @@ class TimeData:
     expires_at: Optional[datetime]
     # only exists for cancelled executions
     cancelled_at: Optional[datetime]
-    
+
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TimeData:
         """Constructor from dictionary. See unit test for sample input."""
-        end = data.get("execution_ended_at", None)
-        expires = data.get("expires_at", None)
+        end = data.get("execution_ended_at")
+        expires = data.get("expires_at")
+        cancelled = data.get("cancelled_at")
         return cls(
             submitted_at=parse(data["submitted_at"]),
             expires_at=None if expires is None else parse(expires),
             execution_started_at=parse(data["execution_started_at"]),
             execution_ended_at=None if end is None else parse(end),
+            cancelled_at=None if cancelled is None else parse(cancelled),
         )
 
 
@@ -93,7 +95,7 @@ class ExecutionStatusResponse:
     @classmethod
     def from_dict(cls, data: dict[str, str]) -> ExecutionStatusResponse:
         """Constructor from dictionary. See unit test for sample input."""
-        dct =  data.get("result_metadata")
+        dct = data.get("result_metadata")
         result_metadata = ResultMetadata.from_dict(dct) if dct else None
         return cls(
             execution_id=data["execution_id"],
@@ -125,7 +127,7 @@ class ResultMetadata:
         assert isinstance(data["total_row_count"], int)
         assert isinstance(data["datapoint_count"], int)
         assert isinstance(data["pending_time_millis"], int)
-        assert isinstance(data["execution_time_millis"], int)    
+        assert isinstance(data["execution_time_millis"], int)
         return cls(
             column_names=data["column_names"],
             result_set_bytes=data["result_set_bytes"],

--- a/dune_client/models.py
+++ b/dune_client/models.py
@@ -96,12 +96,11 @@ class ExecutionStatusResponse:
     def from_dict(cls, data: dict[str, Any]) -> ExecutionStatusResponse:
         """Constructor from dictionary. See unit test for sample input."""
         dct: Optional[MetaData] = data.get("result_metadata")
-        result_metadata = ResultMetadata.from_dict(dct) if dct else None
         return cls(
             execution_id=data["execution_id"],
             query_id=int(data["query_id"]),
             state=ExecutionState(data["state"]),
-            result_metadata=result_metadata,
+            result_metadata=ResultMetadata.from_dict(dct) if dct else None,
             times=TimeData.from_dict(data),  # Sending the entire data dict
         )
 
@@ -134,7 +133,7 @@ class ResultMetadata:
             total_row_count=data["total_row_count"],
             datapoint_count=data["datapoint_count"],
             pending_time_millis=data["pending_time_millis"],
-            execution_time_millis=data["pending_time_millis"],
+            execution_time_millis=data["execution_time_millis"],
         )
 
 

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -32,7 +32,7 @@ class TestDuneClient(unittest.TestCase):
         self.valid_api_key = os.environ["DUNE_API_KEY"]
 
     def test_get_status(self):
-        query = Query(name="No Name", query_id=649345, params=[])
+        query = Query(name="No Name", query_id=1276442, params=[])
         dune = DuneClient(self.valid_api_key)
         job_id = dune.execute(query).execution_id
         status = dune.get_status(job_id)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -30,6 +30,23 @@ class MyTestCase(unittest.TestCase):
             "submitted_at": "2022-08-29T06:33:24.913138Z",
             "execution_started_at": "2022-08-29T06:33:24.916543331Z",
         }
+        self.result_metadata_data = {
+            "column_names": ["ct", "TableName"],
+            "result_set_bytes": 194,
+            "total_row_count": 8,
+            "datapoint_count": 2,
+            "pending_time_millis": 54,
+            "execution_time_millis": 900,
+        }
+        self.status_response_data_completed = {
+            "execution_id": self.execution_id,
+            "query_id": self.query_id,
+            "state": "QUERY_STATE_EXECUTING",
+            "submitted_at": "2022-08-29T06:33:24.913138Z",
+            "execution_started_at": "2022-08-29T06:33:24.916543331Z",
+            "execution_ended_at": "2022-08-29T06:33:25.816543331Z",
+            "result_metadata": self.result_metadata_data,
+        }
         self.results_response_data = {
             "execution_id": self.execution_id,
             "query_id": self.query_id,
@@ -43,11 +60,7 @@ class MyTestCase(unittest.TestCase):
                     {"TableName": "eth_blocks", "ct": 6296},
                     {"TableName": "eth_traces", "ct": 4474223},
                 ],
-                "metadata": {
-                    "column_names": ["ct", "TableName"],
-                    "result_set_bytes": 194,
-                    "total_row_count": 8,
-                },
+                "metadata": self.result_metadata_data,
             },
         }
 
@@ -97,15 +110,36 @@ class MyTestCase(unittest.TestCase):
             expected, ExecutionStatusResponse.from_dict(self.status_response_data)
         )
 
+    def test_parse_status_response_completed(self):
+        self.assertEqual(
+            ExecutionStatusResponse(
+                execution_id="01GBM4W2N0NMCGPZYW8AYK4YF1",
+                query_id=980708,
+                state=ExecutionState.COMPLETED,
+                times=TimeData.from_dict(self.status_response_data),
+                result_metadata=ResultMetadata.from_dict(self.result_metadata_data),
+            ),
+            ExecutionStatusResponse.from_dict(self.status_response_data_completed),
+        )
+
     def test_parse_result_metadata(self):
         expected = ResultMetadata(
             column_names=["ct", "TableName"],
             result_set_bytes=194,
             total_row_count=8,
+            datapoint_count=2,
+            pending_time_millis=54,
+            execution_time_millis=900,
         )
         self.assertEqual(
             expected,
             ResultMetadata.from_dict(self.results_response_data["result"]["metadata"]),
+        )
+        self.assertEqual(
+            expected,
+            ResultMetadata.from_dict(
+                self.status_response_data_completed["result_metadata"]
+            ),
         )
 
     def test_parse_execution_result(self):

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -85,7 +85,7 @@ class MyTestCase(unittest.TestCase):
             expires_at=datetime(2024, 8, 28, 6, 36, 41, 588470, tzinfo=tzutc()),
             execution_started_at=parse(self.execution_start_str),
             execution_ended_at=parse(self.execution_end_str),
-            cancelled_at=None
+            cancelled_at=None,
         )
         self.assertEqual(
             expected_with_end, TimeData.from_dict(self.results_response_data)
@@ -96,7 +96,7 @@ class MyTestCase(unittest.TestCase):
             expires_at=None,
             execution_started_at=parse(self.execution_start_str),
             execution_ended_at=parse(self.execution_end_str),
-            cancelled_at=None
+            cancelled_at=None,
         )
         self.assertEqual(
             expected_with_empty_optionals, TimeData.from_dict(self.status_response_data)
@@ -108,7 +108,7 @@ class MyTestCase(unittest.TestCase):
             query_id=980708,
             state=ExecutionState.EXECUTING,
             times=TimeData.from_dict(self.status_response_data),
-            result_metadata=None
+            result_metadata=None,
         )
         self.assertEqual(
             expected, ExecutionStatusResponse.from_dict(self.status_response_data)


### PR DESCRIPTION
DuneAPI will return some additional metadata fields that are useful.
- datapoint count (number of columns * rows)
- pending and execution time

Also, the status response has this information if the query execution has completed. Clarify when "expires_at" exists and also add "cancelled_at"