### PR TITLE
Add Copyright Notice and CLA Workflow

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,0 +1,36 @@
+name: "cla"
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Get Team Members"
+        id: team
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.ORG_TOKEN }}
+          result-encoding: string
+          script: |
+            const members = await github.paginate(
+              github.rest.orgs.listMembers,
+              { org: "cowprotocol" },
+            );
+            return members.map(m => m.login).join(",");
+
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.1.3-beta
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN : ${{ secrets.ORG_TOKEN }}
+        with:
+          branch: 'cla-signatures'
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/cowprotocol/cla/blob/main/Cow%20Services%20CLA.md'
+          allowlist: '${{ steps.team.outputs.result }},*[bot]'

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,6 @@
+# Intellectual Property Notice
+ 
+Copyright (c) 2022 Cow Services Lda
+
+Except as otherwise noted (below and/or in individual files), this project is licensed under
+the Apache License, Version 2.0 ([`LICENSE-APACHE`](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>).


### PR DESCRIPTION
We add 
1. A github action to gather CLA signatures for external contributors.
2. A copyright notice.
