### PR TITLE
Fix API response parsing

### DIFF
--- a/dune_client/client.py
+++ b/dune_client/client.py
@@ -57,15 +57,13 @@ class DuneClient(DuneInterface):
 
     def _get(self, url: str) -> Any:
         log.debug(f"GET received input url={url}")
-        response = requests.get(
-            url, headers={"x-dune-api-key": self.token}, timeout=120
-        )
+        response = requests.get(url, headers={"x-dune-api-key": self.token}, timeout=10)
         return self._handle_response(response)
 
     def _post(self, url: str, params: Any) -> Any:
         log.debug(f"POST received input url={url}, params={params}")
         response = requests.post(
-            url=url, json=params, headers={"x-dune-api-key": self.token}, timeout=120
+            url=url, json=params, headers={"x-dune-api-key": self.token}, timeout=5
         )
         return self._handle_response(response)
 
@@ -121,9 +119,16 @@ class DuneClient(DuneInterface):
         Sleeps `ping_frequency` seconds between each status request.
         """
         job_id = self.execute(query).execution_id
-        while self.get_status(job_id).state != ExecutionState.COMPLETED:
-            log.info(f"waiting for query execution {job_id} to complete")
+        state = self.get_status(job_id).state
+        while state != ExecutionState.COMPLETED:
+            print(
+                f"waiting for query execution {job_id} to complete: current state {state}"
+            )
+            log.info(
+                f"waiting for query execution {job_id} to complete: current state {state}"
+            )
             time.sleep(ping_frequency)
+            state = self.get_status(job_id).state
 
         full_response = self.get_result(job_id)
         assert (

--- a/dune_client/client.py
+++ b/dune_client/client.py
@@ -26,7 +26,7 @@ from dune_client.query import Query
 
 log = logging.getLogger(__name__)
 logging.basicConfig(
-    format="%(asctime)s %(levelname)s %(name)s %(message)s", level=logging.INFO
+    format="%(asctime)s %(levelname)s %(name)s %(message)s", level=logging.DEBUG
 )
 
 BASE_URL = "https://api.dune.com/api/v1"
@@ -82,7 +82,7 @@ class DuneClient(DuneInterface):
         try:
             return ExecutionResponse.from_dict(response_json)
         except KeyError as err:
-            raise DuneError(response_json, "ExecutionResponse") from err
+            raise DuneError(response_json, "ExecutionResponse", err) from err
 
     def get_status(self, job_id: str) -> ExecutionStatusResponse:
         """GET status from Dune API for `job_id` (aka `execution_id`)"""
@@ -92,7 +92,7 @@ class DuneClient(DuneInterface):
         try:
             return ExecutionStatusResponse.from_dict(response_json)
         except KeyError as err:
-            raise DuneError(response_json, "ExecutionStatusResponse") from err
+            raise DuneError(response_json, "ExecutionStatusResponse", err) from err
 
     def get_result(self, job_id: str) -> ResultsResponse:
         """GET results from Dune API for `job_id` (aka `execution_id`)"""
@@ -100,7 +100,7 @@ class DuneClient(DuneInterface):
         try:
             return ResultsResponse.from_dict(response_json)
         except KeyError as err:
-            raise DuneError(response_json, "ResultsResponse") from err
+            raise DuneError(response_json, "ResultsResponse", err) from err
 
     def cancel_execution(self, job_id: str) -> bool:
         """POST Execution Cancellation to Dune API for `job_id` (aka `execution_id`)"""
@@ -112,7 +112,7 @@ class DuneClient(DuneInterface):
             success: bool = response_json["success"]
             return success
         except KeyError as err:
-            raise DuneError(response_json, "CancellationResponse") from err
+            raise DuneError(response_json, "CancellationResponse", err) from err
 
     def refresh(self, query: Query, ping_frequency: int = 5) -> list[DuneRecord]:
         """

--- a/dune_client/client.py
+++ b/dune_client/client.py
@@ -63,7 +63,7 @@ class DuneClient(DuneInterface):
     def _post(self, url: str, params: Any) -> Any:
         log.debug(f"POST received input url={url}, params={params}")
         response = requests.post(
-            url=url, json=params, headers={"x-dune-api-key": self.token}, timeout=5
+            url=url, json=params, headers={"x-dune-api-key": self.token}, timeout=10
         )
         return self._handle_response(response)
 

--- a/dune_client/client.py
+++ b/dune_client/client.py
@@ -121,9 +121,6 @@ class DuneClient(DuneInterface):
         job_id = self.execute(query).execution_id
         state = self.get_status(job_id).state
         while state != ExecutionState.COMPLETED:
-            print(
-                f"waiting for query execution {job_id} to complete: current state {state}"
-            )
             log.info(
                 f"waiting for query execution {job_id} to complete: current state {state}"
             )

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -31,12 +31,12 @@ class TestDuneClient(unittest.TestCase):
         dotenv.load_dotenv()
         self.valid_api_key = os.environ["DUNE_API_KEY"]
 
-    # def test_get_status(self):
-    #     query = Query(name="No Name", query_id=1276442, params=[])
-    #     dune = DuneClient(self.valid_api_key)
-    #     job_id = dune.execute(query).execution_id
-    #     status = dune.get_status(job_id)
-    #     self.assertEqual(status.state, ExecutionState.EXECUTING)
+    def test_get_status(self):
+        query = Query(name="No Name", query_id=1276442, params=[])
+        dune = DuneClient(self.valid_api_key)
+        job_id = dune.execute(query).execution_id
+        status = dune.get_status(job_id)
+        self.assertEqual(status.state, ExecutionState.EXECUTING)
 
     def test_refresh(self):
         dune = DuneClient(self.valid_api_key)

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -31,12 +31,12 @@ class TestDuneClient(unittest.TestCase):
         dotenv.load_dotenv()
         self.valid_api_key = os.environ["DUNE_API_KEY"]
 
-    def test_get_status(self):
-        query = Query(name="No Name", query_id=1276442, params=[])
-        dune = DuneClient(self.valid_api_key)
-        job_id = dune.execute(query).execution_id
-        status = dune.get_status(job_id)
-        self.assertEqual(status.state, ExecutionState.EXECUTING)
+    # def test_get_status(self):
+    #     query = Query(name="No Name", query_id=1276442, params=[])
+    #     dune = DuneClient(self.valid_api_key)
+    #     job_id = dune.execute(query).execution_id
+    #     status = dune.get_status(job_id)
+    #     self.assertEqual(status.state, ExecutionState.EXECUTING)
 
     def test_refresh(self):
         dune = DuneClient(self.valid_api_key)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -109,6 +109,7 @@ class MyTestCase(unittest.TestCase):
             state=ExecutionState.EXECUTING,
             times=TimeData.from_dict(self.status_response_data),
             result_metadata=None,
+            queue_position=None
         )
         self.assertEqual(
             expected, ExecutionStatusResponse.from_dict(self.status_response_data)
@@ -122,6 +123,7 @@ class MyTestCase(unittest.TestCase):
                 state=ExecutionState.COMPLETED,
                 times=TimeData.from_dict(self.status_response_data),
                 result_metadata=ResultMetadata.from_dict(self.result_metadata_data),
+                queue_position=None
             ),
             ExecutionStatusResponse.from_dict(self.status_response_data_completed),
         )

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -109,7 +109,7 @@ class MyTestCase(unittest.TestCase):
             state=ExecutionState.EXECUTING,
             times=TimeData.from_dict(self.status_response_data),
             result_metadata=None,
-            queue_position=None
+            queue_position=None,
         )
         self.assertEqual(
             expected, ExecutionStatusResponse.from_dict(self.status_response_data)
@@ -123,7 +123,7 @@ class MyTestCase(unittest.TestCase):
                 state=ExecutionState.COMPLETED,
                 times=TimeData.from_dict(self.status_response_data),
                 result_metadata=ResultMetadata.from_dict(self.result_metadata_data),
-                queue_position=None
+                queue_position=None,
             ),
             ExecutionStatusResponse.from_dict(self.status_response_data_completed),
         )


### PR DESCRIPTION
Today was the first day we saw Query State Pending response types with `queue_position`. Had to adapt the response parsing logic to accomodate:

```
    raise DuneError(response_json, "ExecutionStatusResponse") from err
dune_client.models.DuneError: Can't build ExecutionStatusResponse from {'execution_id': '01GDWCZN82CFV43H17977RC2RX', 'query_id': 649345, 'state': 'QUERY_STATE_PENDING', 'queue_position': 33894, 'submitted_at': '2022-09-26T08:00:42.669254Z'}
```