### PR TITLE
Downgrade to Python 3.7

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python 3.10
+      - name: Setup Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.7'
       - name: Install Requirements
         run: pip install -r requirements/dev.txt
       - name: Pylint
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python 3.10
+      - name: Setup Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.7'
       - name: Install Requirements
         run:
           pip install -r requirements/dev.txt
@@ -37,10 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python 3.10
+      - name: Setup Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.7'
       - name: Install Requirements
         run:
           pip install -r requirements/dev.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
   python-dateutil==2.8.2
   requests==2.28.1
   web3==5.30.0
-python_requires = >=3.8
+python_requires = >=3.7
 setup_requires =
     setuptools_scm
 


### PR DESCRIPTION
Similar to #19 - we downgrade to 3.7 (was pretty easy).