### PR TITLE
Reduced Requirements

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 -r prod.txt
-black==22.8.0
-pylint==2.15.0
-pytest==7.1.3
-python-dotenv==0.21.0
-mypy==0.971
+black>=22.8.0
+pylint>=2.15.0
+pytest>=7.1.3
+python-dotenv>=0.21.0
+mypy>=0.971

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,6 +1,6 @@
-types-python-dateutil==2.8.19
-types-PyYAML==6.0.11
-types-requests==2.28.9
-python-dateutil==2.8.2
-requests==2.28.1
-web3==5.30.0
+types-python-dateutil>=2.8.19
+types-PyYAML>=6.0.11
+types-requests>=2.28.9
+python-dateutil>=2.8.2
+requests>=2.28.1
+web3>=5.30.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,12 +20,12 @@ zip_safe = False
 packages=find:
 platforms = any
 install_requires =
-  types-python-dateutil==2.8.19
-  types-PyYAML==6.0.11
-  types-requests==2.28.9
-  python-dateutil==2.8.2
-  requests==2.28.1
-  web3==5.30.0
+  types-python-dateutil>=2.8.19
+  types-PyYAML>=6.0.11
+  types-requests>=2.28.9
+  python-dateutil>=2.8.2
+  requests>=2.28.1
+  web3>=5.30.0
 python_requires = >=3.7
 setup_requires =
     setuptools_scm


### PR DESCRIPTION
Changing requirements to inequalities so we don't get conflicts like this in the future

```
ERROR: Cannot install -r requirements.txt (line 1), -r requirements.txt (line 2) and web3>=5.30.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested web3>=5.30.1
    duneapi 6.0.0 depends on web3>=5.28.0
    dune-client 0.0.6 depends on web3==5.30.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
```