### PR TITLE
Refactor: DuneInterface.refresh return type

### DIFF
--- a/dune_client/interface.py
+++ b/dune_client/interface.py
@@ -2,10 +2,9 @@
 Abstract class for a basic Dune Interface with refresh method used by Query Runner.
 """
 from abc import ABC
-from typing import List
 
+from dune_client.models import ResultsResponse
 from dune_client.query import Query
-from dune_client.types import DuneRecord
 
 
 # pylint: disable=too-few-public-methods
@@ -14,7 +13,7 @@ class DuneInterface(ABC):
     User Facing Methods for a Dune Client
     """
 
-    def refresh(self, query: Query) -> List[DuneRecord]:
+    def refresh(self, query: Query) -> ResultsResponse:
         """
         Executes a Dune query, waits till query execution completes,
         fetches and returns the results.

--- a/dune_client/query.py
+++ b/dune_client/query.py
@@ -12,8 +12,8 @@ from dune_client.types import QueryParameter
 class Query:
     """Basic data structure constituting a Dune Analytics Query."""
 
-    name: str
     query_id: int
+    name: Optional[str] = "unnamed"
     params: Optional[List[QueryParameter]] = None
 
     def base_url(self) -> str:
@@ -33,3 +33,10 @@ class Query:
                 [self.base_url(), urllib.parse.quote_plus(params, safe="=&?")]
             )
         return self.base_url()
+
+    def __hash__(self) -> int:
+        """
+        This contains the query ID and the values of relevant parameters.
+        Thus, it is unique for caching purposes
+        """
+        return self.url().__hash__()

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -24,10 +24,26 @@ class TestQueryMonitor(unittest.TestCase):
             self.query.url(),
             "https://dune.com/queries/0?Enum=option1&Text=plain+text&Number=12&Date=2021-01-01+12%3A34%3A56",
         )
-        self.assertEqual(Query("", 0, []).url(), "https://dune.com/queries/0")
+        self.assertEqual(Query(0, "", []).url(), "https://dune.com/queries/0")
 
     def test_parameters(self):
         self.assertEqual(self.query.parameters(), self.query_params)
+
+    def test_hash(self):
+        # Same ID, different params
+        query1 = Query(query_id=0, params=[QueryParameter.text_type("Text", "word1")])
+        query2 = Query(query_id=0, params=[QueryParameter.text_type("Text", "word2")])
+        self.assertNotEqual(hash(query1), hash(query2))
+
+        # Different ID, same
+        query1 = Query(query_id=0)
+        query2 = Query(query_id=1)
+        self.assertNotEqual(hash(query1), hash(query2))
+
+        # Different ID different params
+        query1 = Query(query_id=0)
+        query2 = Query(query_id=1, params=[QueryParameter.number_type("num", 1)])
+        self.assertNotEqual(hash(query1), hash(query2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In order for users to cache results, they need access to the JOB ID of their execution. The refresh method now returns more enriched data giving these advanced options to the user.

We lost the convenience of not having to check for an optional field, but introduced a similar convenience in the `ResultsResponse` (i.e. the new method `get_rows` which performs the necessary assertion check) and always returns a list of dune records.

Bonus feature is the Query__hash__ implementation which will allow people to cache results of different executions of the same query with different parameters.

Closes #25  and closes #27