### PR TITLE
Remove Optional on Query Name

### DIFF
--- a/dune_client/models.py
+++ b/dune_client/models.py
@@ -51,6 +51,9 @@ class ExecutionState(Enum):
         """
         return {cls.COMPLETED, cls.CANCELLED, cls.FAILED}
 
+    def is_complete(self) -> bool:
+        """Returns True is state is completed, otherwise False."""
+        return self == ExecutionState.COMPLETED
 
 @dataclass
 class ExecutionResponse:

--- a/dune_client/models.py
+++ b/dune_client/models.py
@@ -55,6 +55,7 @@ class ExecutionState(Enum):
         """Returns True is state is completed, otherwise False."""
         return self == ExecutionState.COMPLETED
 
+
 @dataclass
 class ExecutionResponse:
     """

--- a/dune_client/query.py
+++ b/dune_client/query.py
@@ -13,7 +13,7 @@ class Query:
     """Basic data structure constituting a Dune Analytics Query."""
 
     query_id: int
-    name: Optional[str] = "unnamed"
+    name: str = "unnamed"
     params: Optional[List[QueryParameter]] = None
 
     def base_url(self) -> str:


### PR DESCRIPTION
This is unnecessary and annoying (since it has a default value). Also closes #30 (adding is_complete to ExecutionState).