### PR TITLE
[Easy] Makefile & QueryParam.__repr__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 *.egg-info
 _version.py
 .idea/
+venv/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+VENV = venv
+PYTHON = $(VENV)/bin/python3
+PIP = $(VENV)/bin/pip
+
+
+$(VENV)/bin/activate: requirements/dev.txt
+	python3 -m venv $(VENV)
+	$(PIP) install --upgrade pip
+	$(PIP) install -r requirements/dev.txt
+
+
+install:
+	make $(VENV)/bin/activate
+
+clean:
+	rm -rf __pycache__
+
+fmt:
+	black ./
+
+lint:
+	pylint dune_client/
+
+types:
+	mypy dune_client/ --strict
+
+check:
+	make fmt
+	make lint
+	make types
+
+test-unit:
+	python -m pytest tests/unit
+
+test-e2e:
+	python -m pytest tests/e2e
+
+test-all:
+	make test-unit
+	make test-e2e

--- a/dune_client/types.py
+++ b/dune_client/types.py
@@ -190,9 +190,13 @@ class QueryParameter:
         raise ValueError(f"Could not parse Query parameter from {obj}")
 
     def __str__(self) -> str:
+        # For less cryptic logging.
         return (
-            f"QueryParameter("
-            f"name: {self.key}, "
-            f"value: {self.value}, "
-            f"type: {self.type.value})"
+            f"Parameter("
+            f"name={self.key}, "
+            f"value={self.value}, "
+            f"type={self.type.value})"
         )
+
+    def __repr__(self) -> str:
+        return str(self)

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1,6 +1,7 @@
 import datetime
 import unittest
 
+from dune_client.query import Query
 from dune_client.types import QueryParameter, Address
 
 
@@ -47,20 +48,41 @@ class TestAddress(unittest.TestCase):
 
 
 class TestQueryParameter(unittest.TestCase):
+    def setUp(self) -> None:
+        self.number_type = QueryParameter.number_type("Number", 1)
+        self.text_type = QueryParameter.text_type("Text", "hello")
+        self.date_type = QueryParameter.date_type(
+            "Date", datetime.datetime(2022, 3, 10)
+        )
+
     def test_constructors_and_to_dict(self):
-        number_type = QueryParameter.number_type("Number", 1)
-        text_type = QueryParameter.text_type("Text", "hello")
-        date_type = QueryParameter.date_type("Date", datetime.datetime(2022, 3, 10))
 
         self.assertEqual(
-            number_type.to_dict(), {"key": "Number", "type": "number", "value": "1"}
+            self.number_type.to_dict(),
+            {"key": "Number", "type": "number", "value": "1"},
         )
         self.assertEqual(
-            text_type.to_dict(), {"key": "Text", "type": "text", "value": "hello"}
+            self.text_type.to_dict(), {"key": "Text", "type": "text", "value": "hello"}
         )
         self.assertEqual(
-            date_type.to_dict(),
+            self.date_type.to_dict(),
             {"key": "Date", "type": "datetime", "value": "2022-03-10 00:00:00"},
+        )
+
+    def test_repr_method(self):
+        query = Query(
+            query_id=1,
+            name="Test Query",
+            params=[self.number_type, self.text_type],
+        )
+
+        self.assertEqual(
+            "Query(query_id=1, name='Test Query', "
+            "params=["
+            "Parameter(name=Number, value=1, type=number), "
+            "Parameter(name=Text, value=hello, type=text)"
+            "])",
+            str(query),
         )
 
 


### PR DESCRIPTION
1. Makefile makes everything easier
2. The __repr__ method makes logging queries human readable

