### PR TITLE
Add FileIO with write & load functionality

### DIFF
--- a/dune_client/file.py
+++ b/dune_client/file.py
@@ -34,7 +34,11 @@ class FileType(Enum):
 
     @classmethod
     def from_str(cls, value: str) -> FileType:
-        """Constructs and instance of FileType from string"""
+        """
+        Constructs and instance of FileType from string
+        This method is used by FileIO constructor,
+        so that users don't have to import this class
+        """
         lowered_value = value.lower()
         if "ndjson" in lowered_value:
             return cls.NDJSON
@@ -74,8 +78,8 @@ class FileType(Enum):
             writer = ndjson.writer(out_file, ensure_ascii=False)
             for row in data:
                 writer.writerow(row)
-
-        raise ValueError(f"Unrecognized FileType {self} for {out_file.name}")
+        else:
+            raise ValueError(f"Unrecognized FileType {self} for {out_file.name}")
 
 
 class FileIO:
@@ -115,7 +119,7 @@ class FileIO:
         if len(data) == 0:
             # TODO - should be able to write empty file,
             #  but without data, we don't know the csv headers for the type!
-            logger.debug(f"Nothing to write to {name}... skipping")
+            logger.info(f"Nothing to write to {name}... skipping")
             return
 
         with open(self._filepath(name), "w", encoding=self.encoding) as out_file:

--- a/dune_client/file.py
+++ b/dune_client/file.py
@@ -94,16 +94,8 @@ class FileIO:
     def __init__(
         self,
         path: Path | str,
-        # ftype: FileType | str = FileType.CSV,
         encoding: str = "utf-8",
     ):
-        # if isinstance(ftype, str):
-        #     try:
-        #         ftype = FileType.from_str(ftype)
-        #     except Exception as err:
-        #         raise err
-        #
-        # self.ftype: FileType = ftype
         if not os.path.exists(path):
             logger.info(f"creating write path {path}")
             os.makedirs(path)
@@ -115,12 +107,10 @@ class FileIO:
         return os.path.join(self.path, name + str(ftype))
 
     def _write(self, data: list[DuneRecord], name: str, ftype: FileType) -> None:
+        # TODO - use @skip_empty decorator here. Couldn't get the types to work.
         if len(data) == 0:
-            # TODO - should be able to write empty file,
-            #  but without data, we don't know the csv headers for the type!
             logger.info(f"Nothing to write to {name}... skipping")
             return
-
         with open(self._filepath(name, ftype), "w", encoding=self.encoding) as out_file:
             ftype.write(out_file, data)
 
@@ -152,3 +142,15 @@ class FileIO:
     def load_ndjson(self, name: str) -> list[DuneRecord]:
         """Loads DuneRecords from ndjson file `name`"""
         return self._load(name, FileType.NDJSON)
+
+    @staticmethod
+    def _parse_ftype(ftype: FileType | str) -> FileType:
+        if isinstance(ftype, str):
+            ftype = FileType.from_str(ftype)
+        return ftype
+
+    def load_singleton(
+        self, name: str, ftype: FileType | str, index: int = 0
+    ) -> DuneRecord:
+        """Loads and returns single entry by index (default 0)"""
+        return self._load(name, self._parse_ftype(ftype))[index]

--- a/dune_client/file.py
+++ b/dune_client/file.py
@@ -1,0 +1,127 @@
+"""File Reader and Writer for DuneRecords"""
+from __future__ import annotations
+
+import csv
+import json
+import logging
+import os.path
+from enum import Enum
+from pathlib import Path
+from typing import TextIO
+
+# ndjson missing types: https://github.com/rhgrant10/ndjson/issues/10
+import ndjson  # type: ignore
+
+from dune_client.types import DuneRecord
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(format="%(asctime)s %(levelname)s %(name)s %(message)s")
+
+
+class FileType(Enum):
+    """
+    Enum variants for supported file types
+    CSV is the most space efficient (least redundant) file format,
+    but some people like others.
+    """
+
+    CSV = ".csv"
+    JSON = ".json"
+    NDJSON = ".ndjson"
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    @classmethod
+    def from_str(cls, value: str) -> FileType:
+        """Constructs and instance of FileType from string"""
+        lowered_value = value.lower()
+        if "ndjson" in lowered_value:
+            return cls.NDJSON
+        if "json" in lowered_value:
+            return cls.JSON
+        if "csv" in lowered_value:
+            return cls.CSV
+        raise ValueError(f"Unrecognized FileType {value}")
+
+    def load(self, file: TextIO) -> list[DuneRecord]:
+        """Loads DuneRecords from file"""
+        logger.debug(f"Attempting to loading results from file {file.name}")
+        if self == FileType.JSON:
+            loaded_file: list[DuneRecord] = json.loads(file.read())
+            return loaded_file
+        if self == FileType.CSV:
+            return list(csv.DictReader(file))
+        if self == FileType.NDJSON:
+            return list(ndjson.reader(file))
+        raise ValueError(f"Unrecognized FileType {self} for {file.name}")
+
+    def write(self, out_file: TextIO, data: list[DuneRecord]) -> None:
+        """Writes `data` to `out_file`"""
+        logger.debug(f"writing results to file {out_file.name}")
+        if self == FileType.CSV:
+            headers = data[0].keys()
+            data_tuple = [tuple(rec.values()) for rec in data]
+            dict_writer = csv.DictWriter(out_file, headers, lineterminator="\n")
+            dict_writer.writeheader()
+            writer = csv.writer(out_file, lineterminator="\n")
+            writer.writerows(data_tuple)
+
+        elif self == FileType.JSON:
+            out_file.write(json.dumps(data))
+
+        elif self == FileType.NDJSON:
+            writer = ndjson.writer(out_file, ensure_ascii=False)
+            for row in data:
+                writer.writerow(row)
+
+        raise ValueError(f"Unrecognized FileType {self} for {out_file.name}")
+
+
+class FileIO:
+    """
+    CSV is a more compact file type,
+        but requires iteration over the set pre and post write
+    JSON is a redundant file format
+        but writes the content exactly as it is received from Dune.
+    NDJSON used for data "streams"
+    """
+
+    def __init__(
+        self,
+        path: Path | str,
+        ftype: FileType | str = FileType.CSV,
+        encoding: str = "utf-8",
+    ):
+        if isinstance(ftype, str):
+            try:
+                ftype = FileType.from_str(ftype)
+            except Exception as err:
+                raise err
+
+        self.ftype: FileType = ftype
+        if not os.path.exists(path):
+            logger.info(f"creating write path {path}")
+            os.makedirs(path)
+        self.path = path
+        self.encoding: str = encoding
+
+    def _filepath(self, name: str) -> str:
+        """Internal method for building absolute path."""
+        return os.path.join(self.path, name + str(self.ftype))
+
+    def write(self, data: list[DuneRecord], name: str) -> None:
+        """Writes `data` to file `name`"""
+        if len(data) == 0:
+            # TODO - should be able to write empty file,
+            #  but without data, we don't know the csv headers for the type!
+            logger.debug(f"Nothing to write to {name}... skipping")
+            return
+
+        with open(self._filepath(name), "w", encoding=self.encoding) as out_file:
+            self.ftype.write(out_file, data)
+
+    def load(self, name: str) -> list[DuneRecord]:
+        """Loads DuneRecords from file `name`"""
+        with open(self._filepath(name), "r", encoding="utf-8") as file:
+            return self.ftype.load(file)

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -4,3 +4,4 @@ types-requests>=2.28.9
 python-dateutil>=2.8.2
 requests>=2.28.1
 web3>=5.30.0
+ndjson>=0.3.1

--- a/tests/unit/dev/test.json.csv
+++ b/tests/unit/dev/test.json.csv
@@ -1,3 +1,0 @@
-col1,col2
-value01,value02
-value11,value12

--- a/tests/unit/dev/test.json.csv
+++ b/tests/unit/dev/test.json.csv
@@ -1,0 +1,3 @@
+col1,col2
+value01,value02
+value11,value12

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -33,47 +33,56 @@ class TestFileIO(unittest.TestCase):
             {"col1": "value01", "col2": "value02"},
             {"col1": "value11", "col2": "value12"},
         ]
+        self.file_manager = FileIO(TEST_PATH)
 
     def tearDown(self) -> None:
         cleanup()
 
-    def test_write_and_load(self):
-        file_manager = FileIO(TEST_PATH)
-        for file_type in FileType:
-            file_manager._write(self.dune_records, TEST_FILE, file_type)
-            loaded_records = file_manager._load(TEST_FILE, file_type)
-            self.assertEqual(self.dune_records, loaded_records)
+    def test_invertible_write_and_load(self):
+        for ftype in FileType:
+            self.file_manager._write(self.dune_records, TEST_FILE, ftype)
+            loaded_records = self.file_manager._load(TEST_FILE, ftype)
+            self.assertEqual(
+                self.dune_records,
+                loaded_records,
+                f"Assert invertible failed on {ftype}",
+            )
 
     def test_load_singleton(self):
-        file_manager = FileIO(TEST_PATH)
         for file_type in FileType:
-            file_manager._write(self.dune_records, TEST_FILE, file_type)
-            entry_0 = file_manager.load_singleton(TEST_FILE, file_type)
-            entry_1 = file_manager.load_singleton(TEST_FILE, file_type, 1)
-            self.assertEqual(self.dune_records[0], entry_0)
-            self.assertEqual(self.dune_records[1], entry_1)
+            self.file_manager._write(self.dune_records, TEST_FILE, file_type)
+            entry_0 = self.file_manager.load_singleton(TEST_FILE, file_type)
+            entry_1 = self.file_manager.load_singleton(TEST_FILE, file_type, 1)
+            self.assertEqual(
+                self.dune_records[0],
+                entry_0,
+                f"load_singletons failed on {file_type} at index 0",
+            )
+            self.assertEqual(
+                self.dune_records[1],
+                entry_1,
+                f"load_singletons failed on {file_type} at index 1",
+            )
 
     def test_skip_empty_write(self):
-        file_manager = FileIO(TEST_PATH)
         for file_type in FileType:
             with self.assertLogs():
-                file_manager._write([], TEST_FILE, file_type)
+                self.file_manager._write([], TEST_FILE, file_type)
             with self.assertRaises(FileNotFoundError):
-                file_manager._load(TEST_FILE, file_type)
+                self.file_manager._load(TEST_FILE, file_type)
 
     def test_idempotent_write(self):
-        file_manager = FileIO(TEST_PATH)
         for file_type in FileType:
-            file_manager._write(self.dune_records, TEST_FILE, file_type)
-            file_manager._write(self.dune_records, TEST_FILE, file_type)
+            self.file_manager._write(self.dune_records, TEST_FILE, file_type)
+            self.file_manager._write(self.dune_records, TEST_FILE, file_type)
             self.assertEqual(
-                self.dune_records, file_manager._load(TEST_FILE, file_type)
+                self.dune_records,
+                self.file_manager._load(TEST_FILE, file_type),
+                f"idempotent write failed on {file_type}",
             )
 
     def test_file_type(self):
-        for enum_instance in FileType:
-            self.assertEqual(enum_instance, FileType.from_str(str(enum_instance)))
-        # The above is equivalent to, but also covers new items when added.
-        # self.assertEqual(FileType.CSV, FileType.from_str("csv"))
-        # self.assertEqual(FileType.JSON, FileType.from_str("json"))
-        # self.assertEqual(FileType.NDJSON, FileType.from_str("ndjson"))
+        for file_type in FileType:
+            self.assertEqual(
+                file_type, FileType.from_str(str(file_type)), "failed on {file_type}"
+            )

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -7,14 +7,20 @@ TEST_FILE = "test"
 TEST_PATH = "tmp"
 
 
+def cleanup():
+    for extension in [e.value for e in FileType]:
+        try:
+            os.remove(os.path.join(TEST_PATH, TEST_FILE + str(extension)))
+        except FileNotFoundError:
+            pass
+
+
 def cleanup_files(func):
+    """This decorator can be used for testing methods outside of this class"""
+
     def wrapped_func(self):
         func(self)
-        for extension in [e.value for e in FileType]:
-            try:
-                os.remove(os.path.join(TEST_PATH, TEST_FILE + str(extension)))
-            except FileNotFoundError:
-                pass
+        cleanup()
 
     return wrapped_func
 
@@ -28,13 +34,24 @@ class TestFileIO(unittest.TestCase):
             {"col1": "value11", "col2": "value12"},
         ]
 
-    @cleanup_files
+    def tearDown(self) -> None:
+        cleanup()
+
     def test_write_and_load(self):
         file_manager = FileIO(TEST_PATH)
         for file_type in FileType:
             file_manager._write(self.dune_records, TEST_FILE, file_type)
             loaded_records = file_manager._load(TEST_FILE, file_type)
-            self.assertEqual(self.dune_records, loaded_records, file_type)
+            self.assertEqual(self.dune_records, loaded_records)
+
+    def test_load_singleton(self):
+        file_manager = FileIO(TEST_PATH)
+        for file_type in FileType:
+            file_manager._write(self.dune_records, TEST_FILE, file_type)
+            entry_0 = file_manager.load_singleton(TEST_FILE, file_type)
+            entry_1 = file_manager.load_singleton(TEST_FILE, file_type, 1)
+            self.assertEqual(self.dune_records[0], entry_0)
+            self.assertEqual(self.dune_records[1], entry_1)
 
     def test_skip_empty_write(self):
         file_manager = FileIO(TEST_PATH)
@@ -43,6 +60,15 @@ class TestFileIO(unittest.TestCase):
                 file_manager._write([], TEST_FILE, file_type)
             with self.assertRaises(FileNotFoundError):
                 file_manager._load(TEST_FILE, file_type)
+
+    def test_idempotent_write(self):
+        file_manager = FileIO(TEST_PATH)
+        for file_type in FileType:
+            file_manager._write(self.dune_records, TEST_FILE, file_type)
+            file_manager._write(self.dune_records, TEST_FILE, file_type)
+            self.assertEqual(
+                self.dune_records, file_manager._load(TEST_FILE, file_type)
+            )
 
     def test_file_type(self):
         for enum_instance in FileType:

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -51,6 +51,9 @@ class TestFileIO(unittest.TestCase):
                 file_manager.load(TEST_FILE)
 
     def test_file_type(self):
-        self.assertEqual(FileType.CSV, FileType.from_str("csv"))
-        self.assertEqual(FileType.JSON, FileType.from_str("json"))
-        self.assertEqual(FileType.JSON, FileType.from_str("ndjson"))
+        for enum_instance in FileType:
+            self.assertEqual(enum_instance, FileType.from_str(str(enum_instance)))
+        # The above is equivalent to, but also covers new items when added.
+        # self.assertEqual(FileType.CSV, FileType.from_str("csv"))
+        # self.assertEqual(FileType.JSON, FileType.from_str("json"))
+        # self.assertEqual(FileType.NDJSON, FileType.from_str("ndjson"))

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -1,0 +1,56 @@
+import os
+import unittest
+
+from dune_client.file import FileIO, FileType
+
+TEST_FILE = "test"
+TEST_PATH = "tmp"
+
+
+def cleanup_files(func):
+    def wrapped_func(self):
+        func(self)
+        for extension in [e.value for e in FileType]:
+            try:
+                os.remove(os.path.join(TEST_PATH, TEST_FILE + str(extension)))
+            except FileNotFoundError:
+                pass
+
+    return wrapped_func
+
+
+class TestFileIO(unittest.TestCase):
+    """These tests indirectly test FileType's read and write functionality."""
+
+    def setUp(self) -> None:
+        self.dune_records = [
+            {"col1": "value01", "col2": "value02"},
+            {"col1": "value11", "col2": "value12"},
+        ]
+        self.csv_manager = FileIO(TEST_PATH, FileType.CSV)
+        self.json_manager = FileIO(TEST_PATH, FileType.JSON)
+        self.ndjson_type = FileIO(TEST_PATH, FileType.NDJSON)
+        self.file_managers = [
+            self.csv_manager,
+            self.json_manager,
+            self.ndjson_type,
+        ]
+
+    @cleanup_files
+    def test_write_and_load(self):
+        for file_manager in self.file_managers:
+            file_manager.write(self.dune_records, TEST_FILE)
+            loaded_records = file_manager.load(TEST_FILE)
+            self.assertEqual(self.dune_records, loaded_records)
+
+    def test_skip_empty_write(self):
+        for file_manager in self.file_managers:
+            with self.assertLogs():
+                file_manager.write([], TEST_FILE)
+            with self.assertRaises(FileNotFoundError):
+                file_manager.load(TEST_FILE)
+
+    def test_file_type(self):
+        self.assertEqual(FileType.CSV, FileType.from_str("csv"))
+        self.assertEqual(FileType.JSON, FileType.from_str("json"))
+        self.assertEqual(FileType.JSON, FileType.from_str("ndjson"))

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -27,28 +27,22 @@ class TestFileIO(unittest.TestCase):
             {"col1": "value01", "col2": "value02"},
             {"col1": "value11", "col2": "value12"},
         ]
-        self.csv_manager = FileIO(TEST_PATH, FileType.CSV)
-        self.json_manager = FileIO(TEST_PATH, FileType.JSON)
-        self.ndjson_type = FileIO(TEST_PATH, FileType.NDJSON)
-        self.file_managers = [
-            self.csv_manager,
-            self.json_manager,
-            self.ndjson_type,
-        ]
 
     @cleanup_files
     def test_write_and_load(self):
-        for file_manager in self.file_managers:
-            file_manager.write(self.dune_records, TEST_FILE)
-            loaded_records = file_manager.load(TEST_FILE)
-            self.assertEqual(self.dune_records, loaded_records)
+        file_manager = FileIO(TEST_PATH)
+        for file_type in FileType:
+            file_manager._write(self.dune_records, TEST_FILE, file_type)
+            loaded_records = file_manager._load(TEST_FILE, file_type)
+            self.assertEqual(self.dune_records, loaded_records, file_type)
 
     def test_skip_empty_write(self):
-        for file_manager in self.file_managers:
+        file_manager = FileIO(TEST_PATH)
+        for file_type in FileType:
             with self.assertLogs():
-                file_manager.write([], TEST_FILE)
+                file_manager._write([], TEST_FILE, file_type)
             with self.assertRaises(FileNotFoundError):
-                file_manager.load(TEST_FILE)
+                file_manager._load(TEST_FILE, file_type)
 
     def test_file_type(self):
         for enum_instance in FileType:


### PR DESCRIPTION
This tool can easily write and load Dune Query Results (list[DuneRecord]) to and from file. Comes equip with a fully tested suite of file types (CSV, JSON, NDJSON). There is also a load_singleton convenience method.

Tests added demonstrate that the operations are invertible (and thus, also interchangeable). We will extend this tool later to implement a type-of "Caching" Dune Fetcher


Note that this branch is currently published in beta and already being used in this [draft PR](https://github.com/cowprotocol/dune-bridge/pull/37)

### TODO (Later)

- Implement `FileIO._append`. This will be a bit trickier (only in the case of CSV) because we don't want to append the headers again. Issue created here - https://github.com/cowprotocol/dune-client/issues/37

### Test Plan

Run the new tests.