### PR TITLE
Update Install Requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
   python-dateutil>=2.8.2
   requests>=2.28.1
   web3>=5.30.0
+  ndjson>=0.3.1
 python_requires = >=3.7
 setup_requires =
     setuptools_scm


### PR DESCRIPTION
Recent changes adding `FileIO` introduced a dependency that isn't explicitly mentioned in the requirements. I am not super fond of adding this random library to the base requirements...

An alternative approach would be to move the import statement locally into the code path that touches it... What does every one think here?

Another alternative is to move the three different file types into their own modules so that trying to access `write_csv` methods doesn't result in irrelevant errors like:

```
ModuleNotFoundError: No module named 'ndjson'
```