### PR TITLE
Update Python Version Support (remove web3)

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -4,14 +4,18 @@ on:
   push:
     branches: [ main ]
 jobs:
-  lint-format-types:
+  lint-format-types-unit:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python 3.7
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: ${{ matrix.python-version }}
+
       - name: Install Requirements
         run: pip install -r requirements/dev.txt
       - name: Pylint
@@ -20,27 +24,21 @@ jobs:
         run: black --check ./
       - name: Type Check (mypy)
         run: mypy dune_client --strict
-  unit-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Python 3.7
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
-      - name: Install Requirements
-        run:
-          pip install -r requirements/dev.txt
       - name: Unit Tests
         run: python -m pytest tests/unit
+
   e2e-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.11"]
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python 3.7
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: ${{ matrix.python-version }}
+
       - name: Install Requirements
         run:
           pip install -r requirements/dev.txt

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/dune_client/types.py
+++ b/dune_client/types.py
@@ -10,8 +10,6 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict
 
-from web3 import Web3
-
 from dune_client.util import postgres_date
 
 DuneRecord = Dict[str, str]
@@ -31,7 +29,7 @@ class Address:
         # so they don't have to convert all addresses to hex strings manually
         address = address.replace("\\x", "0x")
         if Address._is_valid(address):
-            self.address: str = Web3.toChecksumAddress(address)
+            self.address: str = address.lower()
         else:
             raise ValueError(f"Invalid Ethereum Address {address}")
 

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,3 +1,4 @@
+aiohttp>=3.8.3
 types-python-dateutil>=2.8.19
 types-PyYAML>=6.0.11
 types-requests>=2.28.9

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -3,5 +3,4 @@ types-PyYAML>=6.0.11
 types-requests>=2.28.9
 python-dateutil>=2.8.2
 requests>=2.28.1
-web3>=5.30.0
 ndjson>=0.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ install_requires =
   types-requests>=2.28.9
   python-dateutil>=2.8.2
   requests>=2.28.1
+  aiohttp>=3.8.3
 python_requires = >=3.7
 setup_requires =
     setuptools_scm

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,6 @@ install_requires =
   types-requests>=2.28.9
   python-dateutil>=2.8.2
   requests>=2.28.1
-  web3>=5.30.0
 python_requires = >=3.7
 setup_requires =
     setuptools_scm

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -141,7 +141,7 @@ class TestDuneClient(unittest.TestCase):
             dune.execute(query)
         self.assertEqual(
             str(err.exception),
-            "Can't build ExecutionResponse from {'error': 'An internal error occured'}",
+            "Can't build ExecutionResponse from {'error': 'Query not found'}",
         )
 
     def test_invalid_job_id_error(self):

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -22,15 +22,15 @@ class TestAddress(unittest.TestCase):
     def test_valid(self):
         self.assertEqual(
             Address(address=self.lower_case_address).address,
-            "0xdE1c59Bc25D806aD9DdCbe246c4B5e5505645718",
+            "0xde1c59bc25d806ad9ddcbe246c4b5e5505645718",
         )
         self.assertEqual(
             Address(address=self.check_sum_address).address,
-            "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+            "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
         )
         self.assertEqual(
             Address(address=self.dune_format).address,
-            "0x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6",
+            "0x5d4020b9261f01b6f8a45db929704b0ad6f5e9e6",
         )
 
     def test_inequality(self):


### PR DESCRIPTION
web3 is not ready for 3.11. Luckily it was only used in one place and for not a very good reason (checkSumAddresses). Dune V2 uses lower case strings and our regex pattern can validate addresses without web3. This change may break some peoples tests (if they have hard coded addresses).