### PR TITLE
feat: add async support for csv and dataframe methods

### DIFF
--- a/dune_client/client.py
+++ b/dune_client/client.py
@@ -33,10 +33,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
     combining the use of endpoints (e.g. refresh)
     """
 
-    def _handle_response(
-        self,
-        response: Response,
-    ) -> Any:
+    def _handle_response(self, response: Response) -> Any:
         try:
             # Some responses can be decoded and converted to DuneErrors
             response_json = response.json()

--- a/dune_client/client.py
+++ b/dune_client/client.py
@@ -47,7 +47,12 @@ class DuneClient(DuneInterface, BaseDuneClient):
     def _route_url(self, route: str) -> str:
         return f"{self.BASE_URL}{self.API_PATH}{route}"
 
-    def _get(self, route: str, params: Optional[Any] = None, raw: bool = False) -> Any:
+    def _get(
+        self,
+        route: str,
+        params: Optional[Any] = None,
+        raw: bool = False,
+    ) -> Any:
         url = self._route_url(route)
         self.logger.debug(f"GET received input url={url}")
         response = requests.get(
@@ -75,11 +80,15 @@ class DuneClient(DuneInterface, BaseDuneClient):
         self, query: Query, performance: Optional[str] = None
     ) -> ExecutionResponse:
         """Post's to Dune API for execute `query`"""
+        params = query.request_format()
+        params["performance"] = performance or self.performance
+
         self.logger.info(
             f"executing {query.query_id} on {performance or self.performance} cluster"
         )
         response_json = self._post(
-            route=f"/query/{query.query_id}/execute", params=query.request_format()
+            route=f"/query/{query.query_id}/execute",
+            params=params,
         )
         try:
             return ExecutionResponse.from_dict(response_json)
@@ -135,7 +144,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
             query_id = int(query)
 
         response_json = self._get(
-            route=f"query/{query_id}/results",
+            route=f"/query/{query_id}/results",
             params=params,
         )
         try:
@@ -162,6 +171,11 @@ class DuneClient(DuneInterface, BaseDuneClient):
         ping_frequency: int = 5,
         performance: Optional[str] = None,
     ) -> str:
+        """
+        Executes a Dune `query`, waits until execution completes,
+        fetches and returns the results.
+        Sleeps `ping_frequency` seconds between each status request.
+        """
         job_id = self.execute(query=query, performance=performance).execution_id
         status = self.get_status(job_id)
         while status.state not in ExecutionState.terminal_states():
@@ -177,10 +191,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
         return job_id
 
     def refresh(
-        self,
-        query: Query,
-        ping_frequency: int = 5,
-        performance: Optional[str] = None,
+        self, query: Query, ping_frequency: int = 5, performance: Optional[str] = None
     ) -> ResultsResponse:
         """
         Executes a Dune `query`, waits until execution completes,
@@ -188,17 +199,12 @@ class DuneClient(DuneInterface, BaseDuneClient):
         Sleeps `ping_frequency` seconds between each status request.
         """
         job_id = self._refresh(
-            query,
-            ping_frequency=ping_frequency,
-            performance=performance,
+            query, ping_frequency=ping_frequency, performance=performance
         )
         return self.get_result(job_id)
 
     def refresh_csv(
-        self,
-        query: Query,
-        ping_frequency: int = 5,
-        performance: Optional[str] = None,
+        self, query: Query, ping_frequency: int = 5, performance: Optional[str] = None
     ) -> ExecutionResultCSV:
         """
         Executes a Dune query, waits till execution completes,
@@ -206,9 +212,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
         (use it load the data directly in pandas.from_csv() or similar frameworks)
         """
         job_id = self._refresh(
-            query,
-            ping_frequency=ping_frequency,
-            performance=performance,
+            query, ping_frequency=ping_frequency, performance=performance
         )
         return self.get_result_csv(job_id)
 

--- a/dune_client/client_async.py
+++ b/dune_client/client_async.py
@@ -219,5 +219,5 @@ class AsyncDuneClient(BaseDuneClient):
             raise ImportError(
                 "dependency failure, pandas is required but missing"
             ) from exc
-        data = await self.refresh_csv(query).data
+        data = await (self.refresh_csv(query)).data
         return pandas.read_csv(data)

--- a/dune_client/client_async.py
+++ b/dune_client/client_async.py
@@ -153,13 +153,10 @@ class AsyncDuneClient(BaseDuneClient):
         use this method for large results where you want lower CPU and memory overhead
         if you need metadata information use get_results() or get_status()
         """
+        route = f"/execution/{job_id}/results/csv"
         url = self._route_url(f"/execution/{job_id}/results/csv")
         self.logger.debug(f"GET CSV received input url={url}")
-        response = await requests.get(
-            url,
-            headers={"x-dune-api-key": self.token},
-            timeout=self.DEFAULT_TIMEOUT,
-        )
+        response = await self._get(route=route)
         response.raise_for_status()
         return ExecutionResultCSV(data=BytesIO(response.content))
 

--- a/dune_client/client_async.py
+++ b/dune_client/client_async.py
@@ -90,12 +90,14 @@ class AsyncDuneClient(BaseDuneClient):
     def _route_url(self, route: str) -> str:
         return f"{self.API_PATH}{route}"
 
-    async def _get(self, route: str) -> Any:
+    async def _get(self, route: str, raw: bool = False) -> Any:
         url = self._route_url(route)
         if self._session is None:
             raise ValueError("Client is not connected; call `await cl.connect()`")
         self.logger.debug(f"GET received input url={url}")
         response = await self._session.get(url=url, headers=self.default_headers())
+        if raw:
+            return response
         return await self._handle_response(response)
 
     async def _post(self, route: str, params: Any) -> Any:
@@ -147,7 +149,7 @@ class AsyncDuneClient(BaseDuneClient):
         route = f"/execution/{job_id}/results/csv"
         url = self._route_url(f"/execution/{job_id}/results/csv")
         self.logger.debug(f"GET CSV received input url={url}")
-        response = await self._get(route=route)
+        response = await self._get(route=route, raw=True)
         response.raise_for_status()
         return ExecutionResultCSV(data=BytesIO(response.content))
 

--- a/dune_client/client_async.py
+++ b/dune_client/client_async.py
@@ -151,7 +151,7 @@ class AsyncDuneClient(BaseDuneClient):
         self.logger.debug(f"GET CSV received input url={url}")
         response = await self._get(route=route, raw=True)
         response.raise_for_status()
-        return ExecutionResultCSV(data=BytesIO(response.content))
+        return ExecutionResultCSV(data=response.content)
 
     async def cancel_execution(self, job_id: str) -> bool:
         """POST Execution Cancellation to Dune API for `job_id` (aka `execution_id`)"""

--- a/dune_client/client_async.py
+++ b/dune_client/client_async.py
@@ -219,5 +219,5 @@ class AsyncDuneClient(BaseDuneClient):
             raise ImportError(
                 "dependency failure, pandas is required but missing"
             ) from exc
-        data = await (self.refresh_csv(query)).data
+        data = (await self.refresh_csv(query)).data
         return pandas.read_csv(data)

--- a/dune_client/client_async.py
+++ b/dune_client/client_async.py
@@ -76,10 +76,7 @@ class AsyncDuneClient(BaseDuneClient):
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         await self.disconnect()
 
-    async def _handle_response(
-        self,
-        response: ClientResponse,
-    ) -> Any:
+    async def _handle_response(self, response: ClientResponse) -> Any:
         try:
             # Some responses can be decoded and converted to DuneErrors
             response_json = await response.json()
@@ -98,10 +95,7 @@ class AsyncDuneClient(BaseDuneClient):
         if self._session is None:
             raise ValueError("Client is not connected; call `await cl.connect()`")
         self.logger.debug(f"GET received input url={url}")
-        response = await self._session.get(
-            url=url,
-            headers=self.default_headers(),
-        )
+        response = await self._session.get(url=url, headers=self.default_headers())
         return await self._handle_response(response)
 
     async def _post(self, route: str, params: Any) -> Any:
@@ -119,8 +113,7 @@ class AsyncDuneClient(BaseDuneClient):
     async def execute(self, query: Query) -> ExecutionResponse:
         """Post's to Dune API for execute `query`"""
         response_json = await self._post(
-            route=f"/query/{query.query_id}/execute",
-            params=query.request_format(),
+            route=f"/query/{query.query_id}/execute", params=query.request_format()
         )
         try:
             return ExecutionResponse.from_dict(response_json)
@@ -129,9 +122,7 @@ class AsyncDuneClient(BaseDuneClient):
 
     async def get_status(self, job_id: str) -> ExecutionStatusResponse:
         """GET status from Dune API for `job_id` (aka `execution_id`)"""
-        response_json = await self._get(
-            route=f"/execution/{job_id}/status",
-        )
+        response_json = await self._get(route=f"/execution/{job_id}/status")
         try:
             return ExecutionStatusResponse.from_dict(response_json)
         except KeyError as err:
@@ -162,7 +153,9 @@ class AsyncDuneClient(BaseDuneClient):
 
     async def cancel_execution(self, job_id: str) -> bool:
         """POST Execution Cancellation to Dune API for `job_id` (aka `execution_id`)"""
-        response_json = await self._post(route=f"/execution/{job_id}/cancel", params=None)
+        response_json = await self._post(
+            route=f"/execution/{job_id}/cancel", params=None
+        )
         try:
             # No need to make a dataclass for this since it's just a boolean.
             success: bool = response_json["success"]
@@ -194,7 +187,9 @@ class AsyncDuneClient(BaseDuneClient):
         job_id = await self._refresh(query, ping_frequency=ping_frequency)
         return await self.get_result(job_id)
 
-    async def refresh_csv(self, query: Query, ping_frequency: int = 5) -> ExecutionResultCSV:
+    async def refresh_csv(
+        self, query: Query, ping_frequency: int = 5
+    ) -> ExecutionResultCSV:
         """
         Executes a Dune query, waits till execution completes,
         fetches and the results in CSV format


### PR DESCRIPTION
opening this as a draft to get some feedback.

- add async versions of `get_result_csv`, `_refresh`, `refresh_csv` and `refresh_into_dataframe`
- reduce diff between `client.py` and `client_async.py`, to make future maintenance easier
- `make test-all` passes 100%

closes #54 