### PR TITLE
add tests on new performance params and get_latest_result

### DIFF
--- a/tests/e2e/test_async_client.py
+++ b/tests/e2e/test_async_client.py
@@ -38,7 +38,7 @@ class TestDuneClient(aiounittest.AsyncTestCase):
             results = (await cl.refresh(self.query, performance="large")).get_rows()
         self.assertGreater(len(results), 0)
 
-    async def test_get_latest_result(self):
+    async def test_get_latest_result_with_query_object(self):
         async with AsyncDuneClient(self.valid_api_key) as cl:
             results = (await cl.get_latest_result(self.query)).get_rows()
         self.assertGreater(len(results), 0)

--- a/tests/e2e/test_async_client.py
+++ b/tests/e2e/test_async_client.py
@@ -33,6 +33,21 @@ class TestDuneClient(aiounittest.AsyncTestCase):
             results = (await cl.refresh(self.query)).get_rows()
         self.assertGreater(len(results), 0)
 
+    async def test_refresh_context_manager_performance_large(self):
+        async with AsyncDuneClient(self.valid_api_key) as cl:
+            results = (await cl.refresh(self.query, performance="large")).get_rows()
+        self.assertGreater(len(results), 0)
+
+    async def test_get_latest_result(self):
+        async with AsyncDuneClient(self.valid_api_key) as cl:
+            results = (await cl.get_latest_result(self.query)).get_rows()
+        self.assertGreater(len(results), 0)
+
+    async def test_get_latest_result_with_query_id(self):
+        async with AsyncDuneClient(self.valid_api_key) as cl:
+            results = (await cl.get_latest_result(self.query.query_id)).get_rows()
+        self.assertGreater(len(results), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -45,6 +45,11 @@ class TestDuneClient(unittest.TestCase):
         results = dune.refresh(self.query).get_rows()
         self.assertGreater(len(results), 0)
 
+    def test_refresh_performance_large(self):
+        dune = DuneClient(self.valid_api_key)
+        results = dune.refresh(self.query, performance="large").get_rows()
+        self.assertGreater(len(results), 0)
+
     def test_refresh_into_dataframe(self):
         dune = DuneClient(self.valid_api_key)
         pd = dune.refresh_into_dataframe(self.query)
@@ -159,6 +164,16 @@ class TestDuneClient(unittest.TestCase):
             "Can't build ExecutionStatusResponse from "
             "{'error': 'The requested execution ID (ID: Wonky Job ID) is invalid.'}",
         )
+
+    def test_get_latest_result_with_query_object(self):
+        dune = DuneClient(self.valid_api_key)
+        results = dune.get_latest_result(self.query).get_rows()
+        self.assertGreater(len(results), 0)
+
+    def test_get_latest_result_with_query_id(self):
+        dune = DuneClient(self.valid_api_key)
+        results = dune.get_latest_result(self.query.query_id).get_rows()
+        self.assertGreater(len(results), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
```
>>> python test_async_client.py
2023-06-05 17:32:06,945 INFO dune_client.base_client executing 1215383 on medium cluster
2023-06-05 17:32:07,594 INFO dune_client.base_client waiting for query execution 01H262ZQPK0T213MA4N9M45G84 to complete: ExecutionState.EXECUTING
...2023-06-05 17:32:13,496 INFO dune_client.base_client executing 1215383 on medium cluster
2023-06-05 17:32:13,887 INFO dune_client.base_client waiting for query execution 01H262ZXTYWNYSS8X74MDZK188 to complete: ExecutionState.EXECUTING
.2023-06-05 17:32:19,062 INFO dune_client.base_client executing 1215383 on large cluster
.2023-06-05 17:32:19,467 INFO dune_client.base_client executing 1215383 on medium cluster
2023-06-05 17:32:19,781 INFO dune_client.base_client waiting for query execution 01H26303NQWR62QXW9F6TY8KQG to complete: ExecutionState.PENDING (queue position: 1)
.
----------------------------------------------------------------------
Ran 6 tests in 18.005s

OK
```


```
>>> python test_client.py      
2023-06-05 17:32:30,759 INFO dune_client.base_client executing 1229120 on medium cluster
.2023-06-05 17:32:31,902 INFO dune_client.base_client executing 1215383 on medium cluster
...2023-06-05 17:32:34,069 INFO dune_client.base_client executing 1276442 on medium cluster
.2023-06-05 17:32:34,722 INFO dune_client.base_client executing 9999999999999 on medium cluster
2023-06-05 17:32:35,044 ERROR dune_client.models Can't build ExecutionResponse from {'error': 'Query not found'} due to KeyError: 'execution_id'
.2023-06-05 17:32:35,045 INFO dune_client.base_client executing 1215383 on medium cluster
2023-06-05 17:32:35,356 ERROR dune_client.models Can't build ExecutionResponse from {'error': 'invalid API Key'} due to KeyError: 'execution_id'
2023-06-05 17:32:35,650 ERROR dune_client.models Can't build ExecutionStatusResponse from {'error': 'invalid API Key'} due to KeyError: 'execution_id'
2023-06-05 17:32:36,015 ERROR dune_client.models Can't build ResultsResponse from {'error': 'invalid API Key'} due to KeyError: 'execution_id'
.2023-06-05 17:32:36,303 ERROR dune_client.models Can't build ExecutionStatusResponse from {'error': 'The requested execution ID (ID: Wonky Job ID) is invalid.'} due to KeyError: 'execution_id'
.2023-06-05 17:32:36,303 INFO dune_client.base_client executing 1215383 on medium cluster
.2023-06-05 17:32:37,328 INFO dune_client.base_client executing 99999999 on medium cluster
2023-06-05 17:32:37,687 ERROR dune_client.models Can't build ExecutionResponse from {'error': 'Query not found'} due to KeyError: 'execution_id'
.2023-06-05 17:32:37,689 INFO dune_client.base_client executing 1215383 on medium cluster
.2023-06-05 17:32:38,973 INFO numexpr.utils NumExpr defaulting to 8 threads.
2023-06-05 17:32:39,161 INFO dune_client.base_client executing 1215383 on medium cluster
.2023-06-05 17:32:40,018 INFO dune_client.base_client executing 1215383 on large cluster
.
----------------------------------------------------------------------
Ran 13 tests in 10.259s

OK
```

