### PR TITLE
[Feature] Introducing CRUD Operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ import os
 
 from dune_client.types import QueryParameter
 from dune_client.client import DuneClient
-from dune_client.query import Query
+from dune_client.query import QueryBase
 
-query = Query(
+query = QueryBase(
     name="Sample Query",
     query_id=1215383,
     params=[

--- a/dune_client/base_client.py
+++ b/dune_client/base_client.py
@@ -17,14 +17,21 @@ class BaseDuneClient:
     """
 
     BASE_URL = "https://api.dune.com"
-    API_PATH = "/api/v1"
     DEFAULT_TIMEOUT = 10
 
-    def __init__(self, api_key: str, performance: str = "medium"):
+    def __init__(
+        self, api_key: str, client_version: str = "v1", performance: str = "medium"
+    ):
         self.token = api_key
+        self.client_version = client_version
         self.performance = performance
         self.logger = logging.getLogger(__name__)
         logging.basicConfig(format="%(asctime)s %(levelname)s %(name)s %(message)s")
+
+    @property
+    def api_version(self) -> str:
+        """Returns client version string"""
+        return f"/api/{self.client_version}"
 
     def default_headers(self) -> Dict[str, str]:
         """Return default headers containing Dune Api token"""

--- a/dune_client/client.py
+++ b/dune_client/client.py
@@ -272,7 +272,6 @@ class DuneClient(DuneInterface, BaseDuneClient):
             params=query_parameters,
         )
         try:
-            # No need to make a dataclass for this since it's just a boolean.
             return int(response_json["query_id"])
         except KeyError as err:
             raise DuneError(response_json, "create_query Response", err) from err

--- a/dune_client/client.py
+++ b/dune_client/client.py
@@ -22,10 +22,9 @@ from dune_client.models import (
     ExecutionStatusResponse,
     ResultsResponse,
     ExecutionState,
-    DuneQuery,
 )
 
-from dune_client.query import Query
+from dune_client.query import QueryBase, DuneQuery
 from dune_client.types import QueryParameter
 
 
@@ -36,6 +35,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
     """
 
     def _handle_response(self, response: Response) -> Any:
+        """Generic response handler utilized by all Dune API routes"""
         try:
             # Some responses can be decoded and converted to DuneErrors
             response_json = response.json()
@@ -55,6 +55,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
         params: Optional[Any] = None,
         raw: bool = False,
     ) -> Any:
+        """Generic interface for the GET method of a Dune API request"""
         url = self._route_url(route)
         self.logger.debug(f"GET received input url={url}")
         response = requests.get(
@@ -68,6 +69,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
         return self._handle_response(response)
 
     def _post(self, route: str, params: Optional[Any] = None) -> Any:
+        """Generic interface for the POST method of a Dune API request"""
         url = self._route_url(route)
         self.logger.debug(f"POST received input url={url}, params={params}")
         response = requests.post(
@@ -79,6 +81,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
         return self._handle_response(response)
 
     def _patch(self, route: str, params: Any) -> Any:
+        """Generic interface for the PATCH method of a Dune API request"""
         url = self._route_url(route)
         self.logger.debug(f"PATCH received input url={url}, params={params}")
         response = requests.request(
@@ -91,7 +94,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
         return self._handle_response(response)
 
     def execute(
-        self, query: Query, performance: Optional[str] = None
+        self, query: QueryBase, performance: Optional[str] = None
     ) -> ExecutionResponse:
         """Post's to Dune API for execute `query`"""
         params = query.request_format()
@@ -140,7 +143,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
         response.raise_for_status()
         return ExecutionResultCSV(data=BytesIO(response.content))
 
-    def get_latest_result(self, query: Union[Query, str, int]) -> ResultsResponse:
+    def get_latest_result(self, query: Union[QueryBase, str, int]) -> ResultsResponse:
         """
         GET the latest results for a query_id without having to execute the query again.
 
@@ -148,7 +151,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
 
         https://dune.com/docs/api/api-reference/latest_results/
         """
-        if isinstance(query, Query):
+        if isinstance(query, QueryBase):
             params = {
                 f"params.{p.key}": p.to_dict()["value"] for p in query.parameters()
             }
@@ -181,7 +184,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
 
     def _refresh(
         self,
-        query: Query,
+        query: QueryBase,
         ping_frequency: int = 5,
         performance: Optional[str] = None,
     ) -> str:
@@ -205,7 +208,10 @@ class DuneClient(DuneInterface, BaseDuneClient):
         return job_id
 
     def refresh(
-        self, query: Query, ping_frequency: int = 5, performance: Optional[str] = None
+        self,
+        query: QueryBase,
+        ping_frequency: int = 5,
+        performance: Optional[str] = None,
     ) -> ResultsResponse:
         """
         Executes a Dune `query`, waits until execution completes,
@@ -218,7 +224,10 @@ class DuneClient(DuneInterface, BaseDuneClient):
         return self.get_result(job_id)
 
     def refresh_csv(
-        self, query: Query, ping_frequency: int = 5, performance: Optional[str] = None
+        self,
+        query: QueryBase,
+        ping_frequency: int = 5,
+        performance: Optional[str] = None,
     ) -> ExecutionResultCSV:
         """
         Executes a Dune query, waits till execution completes,
@@ -231,7 +240,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
         return self.get_result_csv(job_id)
 
     def refresh_into_dataframe(
-        self, query: Query, performance: Optional[str] = None
+        self, query: QueryBase, performance: Optional[str] = None
     ) -> Any:
         """
         Execute a Dune Query, waits till execution completes,
@@ -255,24 +264,23 @@ class DuneClient(DuneInterface, BaseDuneClient):
         query_sql: str,
         params: Optional[list[QueryParameter]] = None,
         is_private: bool = False,
-    ) -> int:
+    ) -> DuneQuery:
         """
         Creates Dune Query by ID
         https://dune.com/docs/api/api-reference/edit-queries/create-query/
         """
-        query_parameters = {
+        parameters = {
             "name": name,
             "query_sql": query_sql,
             "private": is_private,
         }
         if params is not None:
-            query_parameters["parameters"] = [p.to_dict() for p in params]
-        response_json = self._post(
-            route="/query/",
-            params=query_parameters,
-        )
+            parameters["parameters"] = [p.to_dict() for p in params]
+        response_json = self._post(route="/query/", params=parameters)
         try:
-            return int(response_json["query_id"])
+            query_id = int(response_json["query_id"])
+            # Note that this requires an extra request.
+            return self.get_query(query_id)
         except KeyError as err:
             raise DuneError(response_json, "create_query Response", err) from err
 
@@ -332,24 +340,24 @@ class DuneClient(DuneInterface, BaseDuneClient):
     def archive_query(self, query_id: int) -> bool:
         """
         https://dune.com/docs/api/api-reference/edit-queries/archive-query
-        returns resulting value of Query.is_private
+        returns resulting value of Query.is_archived
         """
         response_json = self._post(route=f"/query/{query_id}/archive")
         try:
             # No need to make a dataclass for this since it's just a boolean.
-            return self.get_query(int(response_json["query_id"])).is_archived
+            return self.get_query(int(response_json["query_id"])).meta.is_archived
         except KeyError as err:
             raise DuneError(response_json, "make_private Response", err) from err
 
     def unarchive_query(self, query_id: int) -> bool:
         """
         https://dune.com/docs/api/api-reference/edit-queries/archive-query
-        returns resulting value of Query.is_private
+        returns resulting value of Query.is_archived
         """
         response_json = self._post(route=f"/query/{query_id}/unarchive")
         try:
             # No need to make a dataclass for this since it's just a boolean.
-            return self.get_query(int(response_json["query_id"])).is_archived
+            return self.get_query(int(response_json["query_id"])).meta.is_archived
         except KeyError as err:
             raise DuneError(response_json, "make_private Response", err) from err
 
@@ -359,7 +367,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
         returns resulting value of Query.is_private
         """
         response_json = self._post(route=f"/query/{query_id}/private")
-        assert self.get_query(int(response_json["query_id"])).is_private
+        assert self.get_query(int(response_json["query_id"])).meta.is_private
 
     def make_public(self, query_id: int) -> None:
         """
@@ -367,4 +375,4 @@ class DuneClient(DuneInterface, BaseDuneClient):
         returns resulting value of Query.is_private
         """
         response_json = self._post(route=f"/query/{query_id}/unprivate")
-        assert not self.get_query(int(response_json["query_id"])).is_private
+        assert not self.get_query(int(response_json["query_id"])).meta.is_private

--- a/dune_client/client.py
+++ b/dune_client/client.py
@@ -47,7 +47,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
             raise ValueError("Unreachable since previous line raises") from err
 
     def _route_url(self, route: str) -> str:
-        return f"{self.BASE_URL}{self.api_version}/{route}"
+        return f"{self.BASE_URL}{self.api_version}{route}"
 
     def _get(
         self,
@@ -268,7 +268,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
         if params is not None:
             query_parameters["parameters"] = [p.to_dict() for p in params]
         response_json = self._post(
-            route="query/",
+            route="/query/",
             params=query_parameters,
         )
         try:
@@ -281,7 +281,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
         Retrieves Dune Query by ID
         https://dune.com/docs/api/api-reference/edit-queries/get-query/
         """
-        response_json = self._get(route=f"query/{query_id}")
+        response_json = self._get(route=f"/query/{query_id}")
         return DuneQuery.from_dict(response_json)
 
     def update_query(  # pylint: disable=too-many-arguments
@@ -320,7 +320,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
             return query_id
 
         response_json = self._patch(
-            route=f"query/{query_id}",
+            route=f"/query/{query_id}",
             params=parameters,
         )
         try:
@@ -334,7 +334,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
         https://dune.com/docs/api/api-reference/edit-queries/archive-query
         returns resulting value of Query.is_private
         """
-        response_json = self._post(route=f"query/{query_id}/archive")
+        response_json = self._post(route=f"/query/{query_id}/archive")
         try:
             # No need to make a dataclass for this since it's just a boolean.
             return self.get_query(int(response_json["query_id"])).is_archived
@@ -346,7 +346,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
         https://dune.com/docs/api/api-reference/edit-queries/archive-query
         returns resulting value of Query.is_private
         """
-        response_json = self._post(route=f"query/{query_id}/unarchive")
+        response_json = self._post(route=f"/query/{query_id}/unarchive")
         try:
             # No need to make a dataclass for this since it's just a boolean.
             return self.get_query(int(response_json["query_id"])).is_archived
@@ -358,7 +358,7 @@ class DuneClient(DuneInterface, BaseDuneClient):
         https://dune.com/docs/api/api-reference/edit-queries/private-query
         returns resulting value of Query.is_private
         """
-        response_json = self._post(route=f"query/{query_id}/private")
+        response_json = self._post(route=f"/query/{query_id}/private")
         assert self.get_query(int(response_json["query_id"])).is_private
 
     def make_public(self, query_id: int) -> None:
@@ -366,5 +366,5 @@ class DuneClient(DuneInterface, BaseDuneClient):
         https://dune.com/docs/api/api-reference/edit-queries/private-query
         returns resulting value of Query.is_private
         """
-        response_json = self._post(route=f"query/{query_id}/unprivate")
+        response_json = self._post(route=f"/query/{query_id}/unprivate")
         assert not self.get_query(int(response_json["query_id"])).is_private

--- a/dune_client/client_async.py
+++ b/dune_client/client_async.py
@@ -88,7 +88,7 @@ class AsyncDuneClient(BaseDuneClient):
             raise ValueError("Unreachable since previous line raises") from err
 
     def _route_url(self, route: str) -> str:
-        return f"{self.API_PATH}{route}"
+        return f"{self.api_version}{route}"
 
     async def _get(
         self,

--- a/dune_client/client_async.py
+++ b/dune_client/client_async.py
@@ -28,7 +28,7 @@ from dune_client.models import (
     ExecutionState,
 )
 
-from dune_client.query import Query
+from dune_client.query import QueryBase
 
 
 # pylint: disable=duplicate-code
@@ -122,7 +122,7 @@ class AsyncDuneClient(BaseDuneClient):
         return await self._handle_response(response)
 
     async def execute(
-        self, query: Query, performance: Optional[str] = None
+        self, query: QueryBase, performance: Optional[str] = None
     ) -> ExecutionResponse:
         """Post's to Dune API for execute `query`"""
         params = query.request_format()
@@ -171,7 +171,9 @@ class AsyncDuneClient(BaseDuneClient):
         response.raise_for_status()
         return ExecutionResultCSV(data=BytesIO(await response.content.read(-1)))
 
-    async def get_latest_result(self, query: Union[Query, str, int]) -> ResultsResponse:
+    async def get_latest_result(
+        self, query: Union[QueryBase, str, int]
+    ) -> ResultsResponse:
         """
         GET the latest results for a query_id without having to execute the query again.
 
@@ -179,7 +181,7 @@ class AsyncDuneClient(BaseDuneClient):
 
         https://dune.com/docs/api/api-reference/latest_results/
         """
-        if isinstance(query, Query):
+        if isinstance(query, QueryBase):
             params = {
                 f"params.{p.key}": p.to_dict()["value"] for p in query.parameters()
             }
@@ -212,7 +214,7 @@ class AsyncDuneClient(BaseDuneClient):
 
     async def _refresh(
         self,
-        query: Query,
+        query: QueryBase,
         ping_frequency: int = 5,
         performance: Optional[str] = None,
     ) -> str:
@@ -236,7 +238,10 @@ class AsyncDuneClient(BaseDuneClient):
         return job_id
 
     async def refresh(
-        self, query: Query, ping_frequency: int = 5, performance: Optional[str] = None
+        self,
+        query: QueryBase,
+        ping_frequency: int = 5,
+        performance: Optional[str] = None,
     ) -> ResultsResponse:
         """
         Executes a Dune `query`, waits until execution completes,
@@ -249,7 +254,10 @@ class AsyncDuneClient(BaseDuneClient):
         return await self.get_result(job_id)
 
     async def refresh_csv(
-        self, query: Query, ping_frequency: int = 5, performance: Optional[str] = None
+        self,
+        query: QueryBase,
+        ping_frequency: int = 5,
+        performance: Optional[str] = None,
     ) -> ExecutionResultCSV:
         """
         Executes a Dune query, waits till execution completes,
@@ -262,7 +270,7 @@ class AsyncDuneClient(BaseDuneClient):
         return await self.get_result_csv(job_id)
 
     async def refresh_into_dataframe(
-        self, query: Query, performance: Optional[str] = None
+        self, query: QueryBase, performance: Optional[str] = None
     ) -> Any:
         """
         Execute a Dune Query, waits till execution completes,

--- a/dune_client/client_async.py
+++ b/dune_client/client_async.py
@@ -101,7 +101,7 @@ class AsyncDuneClient(BaseDuneClient):
             raise ValueError("Client is not connected; call `await cl.connect()`")
         self.logger.debug(f"GET received input url={url}")
         response = await self._session.get(
-            url=f"{self.api_version}{url}",
+            url=url,
             headers=self.default_headers(),
             params=params,
         )
@@ -115,7 +115,7 @@ class AsyncDuneClient(BaseDuneClient):
             raise ValueError("Client is not connected; call `await cl.connect()`")
         self.logger.debug(f"POST received input url={url}, params={params}")
         response = await self._session.post(
-            url=f"{self.api_version}{url}",
+            url=url,
             json=params,
             headers=self.default_headers(),
         )

--- a/dune_client/client_async.py
+++ b/dune_client/client_async.py
@@ -92,7 +92,7 @@ class AsyncDuneClient(BaseDuneClient):
             raise ValueError("Client is not connected; call `await cl.connect()`")
         self.logger.debug(f"GET received input url={url}")
         response = await self._session.get(
-            url=f"{self.API_PATH}{url}",
+            url=f"{self.api_version}{url}",
             headers=self.default_headers(),
             params=params,
         )
@@ -103,7 +103,7 @@ class AsyncDuneClient(BaseDuneClient):
             raise ValueError("Client is not connected; call `await cl.connect()`")
         self.logger.debug(f"POST received input url={url}, params={params}")
         response = await self._session.post(
-            url=f"{self.API_PATH}{url}",
+            url=f"{self.api_version}{url}",
             json=params,
             headers=self.default_headers(),
         )

--- a/dune_client/interface.py
+++ b/dune_client/interface.py
@@ -5,7 +5,7 @@ import abc
 from typing import Any
 
 from dune_client.models import ResultsResponse, ExecutionResultCSV
-from dune_client.query import Query
+from dune_client.query import QueryBase
 
 
 # pylint: disable=too-few-public-methods
@@ -15,14 +15,14 @@ class DuneInterface(abc.ABC):
     """
 
     @abc.abstractmethod
-    def refresh(self, query: Query) -> ResultsResponse:
+    def refresh(self, query: QueryBase) -> ResultsResponse:
         """
         Executes a Dune query, waits till query execution completes,
         fetches and returns the results.
         """
 
     @abc.abstractmethod
-    def refresh_csv(self, query: Query) -> ExecutionResultCSV:
+    def refresh_csv(self, query: QueryBase) -> ExecutionResultCSV:
         """
         Executes a Dune query, waits till execution completes,
         fetches and the results in CSV format
@@ -33,7 +33,7 @@ class DuneInterface(abc.ABC):
         """
 
     @abc.abstractmethod
-    def refresh_into_dataframe(self, query: Query) -> Any:
+    def refresh_into_dataframe(self, query: QueryBase) -> Any:
         """
         Execute a Dune Query, waits till execution completes,
         fetched and returns the result as a Pandas DataFrame

--- a/dune_client/models.py
+++ b/dune_client/models.py
@@ -11,8 +11,7 @@ from io import BytesIO
 from typing import Optional, Any, Union, List, Dict
 
 from dateutil.parser import parse
-from dune_client.types import DuneRecord
-
+from dune_client.types import DuneRecord, QueryParameter
 
 log = logging.getLogger(__name__)
 logging.basicConfig(
@@ -251,3 +250,43 @@ class ResultsResponse:
 
         log.info(f"execution {self.state} returning empty list")
         return []
+
+
+@dataclass
+class DuneQuery:  # pylint: disable=too-many-instance-attributes
+    """
+    Modeling the CRUD operation response for `get_query`
+    """
+
+    query_id: int
+    name: str
+    description: str
+    tags: list[str]
+    version: int
+    parameters: list[QueryParameter]
+    query_engine: str
+    query_sql: str
+    is_private: bool
+    is_archived: bool
+    is_unsaved: bool
+    owner: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DuneQuery:
+        """Constructor from json object"""
+        return cls(
+            query_id=int(data["query_id"]),
+            name=data["name"],
+            description=data["description"],
+            tags=data["tags"],
+            version=data["version"],
+            parameters=[
+                QueryParameter.from_dict(param) for param in data["parameters"]
+            ],
+            query_engine=data["query_engine"],
+            query_sql=data["query_sql"],
+            is_private=data["is_private"],
+            is_archived=data["is_archived"],
+            is_unsaved=data["is_unsaved"],
+            owner=data["owner"],
+        )

--- a/dune_client/models.py
+++ b/dune_client/models.py
@@ -11,7 +11,8 @@ from io import BytesIO
 from typing import Optional, Any, Union, List, Dict
 
 from dateutil.parser import parse
-from dune_client.types import DuneRecord, QueryParameter
+
+from dune_client.types import DuneRecord
 
 log = logging.getLogger(__name__)
 logging.basicConfig(
@@ -250,43 +251,3 @@ class ResultsResponse:
 
         log.info(f"execution {self.state} returning empty list")
         return []
-
-
-@dataclass
-class DuneQuery:  # pylint: disable=too-many-instance-attributes
-    """
-    Modeling the CRUD operation response for `get_query`
-    """
-
-    query_id: int
-    name: str
-    description: str
-    tags: list[str]
-    version: int
-    parameters: list[QueryParameter]
-    query_engine: str
-    query_sql: str
-    is_private: bool
-    is_archived: bool
-    is_unsaved: bool
-    owner: str
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> DuneQuery:
-        """Constructor from json object"""
-        return cls(
-            query_id=int(data["query_id"]),
-            name=data["name"],
-            description=data["description"],
-            tags=data["tags"],
-            version=data["version"],
-            parameters=[
-                QueryParameter.from_dict(param) for param in data["parameters"]
-            ],
-            query_engine=data["query_engine"],
-            query_sql=data["query_sql"],
-            is_private=data["is_private"],
-            is_archived=data["is_archived"],
-            is_unsaved=data["is_unsaved"],
-            owner=data["owner"],
-        )

--- a/dune_client/query.py
+++ b/dune_client/query.py
@@ -1,15 +1,16 @@
 """
-Data Class Representing a Dune Query
+Data Classes Representing a Dune Query
 """
+from __future__ import annotations
 import urllib.parse
 from dataclasses import dataclass
-from typing import Optional, List, Dict, Union
+from typing import Optional, List, Dict, Union, Any
 
 from dune_client.types import QueryParameter
 
 
 @dataclass
-class Query:
+class QueryBase:
     """Basic data structure constituting a Dune Analytics Query."""
 
     query_id: int
@@ -46,3 +47,55 @@ class Query:
         return {
             "query_parameters": {p.key: p.to_dict()["value"] for p in self.parameters()}
         }
+
+
+@dataclass
+class QueryMeta:  # pylint: disable=too-many-instance-attributes
+    """
+    Data class containing meta content about the query
+    """
+
+    description: str
+    tags: list[str]
+    version: int
+    engine: str
+    is_private: bool
+    is_archived: bool
+    is_unsaved: bool
+    owner: str
+
+
+@dataclass
+class DuneQuery:
+    """
+    Enriched class representing all data constituting a DuneQuery
+    Modeling the CRUD operation response for `get_query`
+    """
+
+    base: QueryBase
+    meta: QueryMeta
+    sql: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DuneQuery:
+        """Constructor from json object"""
+        return cls(
+            base=QueryBase(
+                query_id=int(data["query_id"]),
+                name=data["name"],
+                params=[
+                    QueryParameter.from_dict(param) for param in data["parameters"]
+                ],
+            ),
+            meta=QueryMeta(
+                description=data["description"],
+                tags=data["tags"],
+                version=data["version"],
+                engine=data["query_engine"],
+                is_private=data["is_private"],
+                is_archived=data["is_archived"],
+                is_unsaved=data["is_unsaved"],
+                owner=data["owner"],
+            ),
+            sql=data["query_sql"],
+        )

--- a/tests/e2e/test_async_client.py
+++ b/tests/e2e/test_async_client.py
@@ -5,12 +5,12 @@ import aiounittest
 import dotenv
 
 from dune_client.client_async import AsyncDuneClient
-from dune_client.query import Query
+from dune_client.query import QueryBase
 
 
 class TestDuneClient(aiounittest.AsyncTestCase):
     def setUp(self) -> None:
-        self.query = Query(name="Sample Query", query_id=1215383)
+        self.query = QueryBase(name="Sample Query", query_id=1215383)
         dotenv.load_dotenv()
         self.valid_api_key = os.environ["DUNE_API_KEY"]
 

--- a/tests/e2e/test_async_client.py
+++ b/tests/e2e/test_async_client.py
@@ -33,6 +33,7 @@ class TestDuneClient(aiounittest.AsyncTestCase):
             results = (await cl.refresh(self.query)).get_rows()
         self.assertGreater(len(results), 0)
 
+    @unittest.skip("Large performance tier doesn't currently work.")
     async def test_refresh_context_manager_performance_large(self):
         async with AsyncDuneClient(self.valid_api_key) as cl:
             results = (await cl.refresh(self.query, performance="large")).get_rows()

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -201,9 +201,12 @@ class TestCRUDOps(unittest.TestCase):
         # Reset:
         self.client.update_query(query_id=test_id, query_sql=current_sql)
 
-    def test_make_private(self):
-        self.assertEqual(self.client.make_private(self.existing_query_id), True)
-        self.assertEqual(self.client.make_public(self.existing_query_id), False)
+    def test_make_private_and_public(self):
+        q_id = self.existing_query_id
+        self.client.make_private(q_id)
+        self.assertEqual(self.client.get_query(q_id).meta.is_private, True)
+        self.client.make_public(q_id)
+        self.assertEqual(self.client.get_query(q_id).meta.is_private, False)
 
     def test_archive(self):
         self.assertEqual(self.client.archive_query(self.existing_query_id), True)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -17,9 +17,9 @@ from dune_client.models import (
     ExecutionResult,
     ResultMetadata,
     DuneError,
-    DuneQuery,
 )
 from dune_client.types import QueryParameter
+from dune_client.query import DuneQuery, QueryMeta, QueryBase
 
 
 class MyTestCase(unittest.TestCase):
@@ -245,22 +245,26 @@ eth_traces,4474223
             "owner": "Owner Name"
         }"""
         expected = DuneQuery(
-            query_id=60066,
-            name="Ethereum transactions",
-            description="Returns ethereum transactions starting from the oldest by block time",
-            tags=["ethereum", "transactions"],
-            version=15,
-            parameters=[
-                QueryParameter.from_dict(
-                    {"key": "limit", "value": "5", "type": "number"}
-                )
-            ],
-            query_engine="v2 Dune SQL",
-            query_sql="select block_number from ethereum.transactions limit {{limit}};",
-            is_private=True,
-            is_archived=False,
-            is_unsaved=False,
-            owner="Owner Name",
+            base=QueryBase(
+                query_id=60066,
+                name="Ethereum transactions",
+                params=[
+                    QueryParameter.from_dict(
+                        {"key": "limit", "value": "5", "type": "number"}
+                    )
+                ],
+            ),
+            meta=QueryMeta(
+                description="Returns ethereum transactions starting from the oldest by block time",
+                tags=["ethereum", "transactions"],
+                version=15,
+                engine="v2 Dune SQL",
+                is_private=True,
+                is_archived=False,
+                is_unsaved=False,
+                owner="Owner Name",
+            ),
+            sql="select block_number from ethereum.transactions limit {{limit}};",
         )
         self.assertEqual(expected, DuneQuery.from_dict(json.loads(example_response)))
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 import csv
 from datetime import datetime
@@ -16,7 +17,9 @@ from dune_client.models import (
     ExecutionResult,
     ResultMetadata,
     DuneError,
+    DuneQuery,
 )
+from dune_client.types import QueryParameter
 
 
 class MyTestCase(unittest.TestCase):
@@ -225,6 +228,41 @@ eth_traces,4474223
             ],
             [r for r in result],
         )
+
+    def test_dune_query_from_dict(self):
+        example_response = """{
+            "query_id": 60066,
+            "name": "Ethereum transactions",
+            "description": "Returns ethereum transactions starting from the oldest by block time",
+            "tags": ["ethereum", "transactions"],
+            "version": 15,
+            "parameters": [{"key": "limit", "value": "5", "type": "number"}],
+            "query_engine": "v2 Dune SQL",
+            "query_sql": "select block_number from ethereum.transactions limit {{limit}};",
+            "is_private": true,
+            "is_archived": false,
+            "is_unsaved": false,
+            "owner": "Owner Name"
+        }"""
+        expected = DuneQuery(
+            query_id=60066,
+            name="Ethereum transactions",
+            description="Returns ethereum transactions starting from the oldest by block time",
+            tags=["ethereum", "transactions"],
+            version=15,
+            parameters=[
+                QueryParameter.from_dict(
+                    {"key": "limit", "value": "5", "type": "number"}
+                )
+            ],
+            query_engine="v2 Dune SQL",
+            query_sql="select block_number from ethereum.transactions limit {{limit}};",
+            is_private=True,
+            is_archived=False,
+            is_unsaved=False,
+            owner="Owner Name",
+        )
+        self.assertEqual(expected, DuneQuery.from_dict(json.loads(example_response)))
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -1,7 +1,7 @@
 import unittest
 from datetime import datetime
 
-from dune_client.query import Query
+from dune_client.query import QueryBase
 from dune_client.types import QueryParameter
 
 
@@ -14,7 +14,7 @@ class TestQueryMonitor(unittest.TestCase):
             QueryParameter.number_type("Number", 12),
             QueryParameter.date_type("Date", "2021-01-01 12:34:56"),
         ]
-        self.query = Query(name="", query_id=0, params=self.query_params)
+        self.query = QueryBase(name="", query_id=0, params=self.query_params)
 
     def test_base_url(self):
         self.assertEqual(self.query.base_url(), "https://dune.com/queries/0")
@@ -24,7 +24,7 @@ class TestQueryMonitor(unittest.TestCase):
             self.query.url(),
             "https://dune.com/queries/0?Enum=option1&Text=plain+text&Number=12&Date=2021-01-01+12%3A34%3A56",
         )
-        self.assertEqual(Query(0, "", []).url(), "https://dune.com/queries/0")
+        self.assertEqual(QueryBase(0, "", []).url(), "https://dune.com/queries/0")
 
     def test_parameters(self):
         self.assertEqual(self.query.parameters(), self.query_params)
@@ -42,18 +42,22 @@ class TestQueryMonitor(unittest.TestCase):
 
     def test_hash(self):
         # Same ID, different params
-        query1 = Query(query_id=0, params=[QueryParameter.text_type("Text", "word1")])
-        query2 = Query(query_id=0, params=[QueryParameter.text_type("Text", "word2")])
+        query1 = QueryBase(
+            query_id=0, params=[QueryParameter.text_type("Text", "word1")]
+        )
+        query2 = QueryBase(
+            query_id=0, params=[QueryParameter.text_type("Text", "word2")]
+        )
         self.assertNotEqual(hash(query1), hash(query2))
 
         # Different ID, same
-        query1 = Query(query_id=0)
-        query2 = Query(query_id=1)
+        query1 = QueryBase(query_id=0)
+        query2 = QueryBase(query_id=1)
         self.assertNotEqual(hash(query1), hash(query2))
 
         # Different ID different params
-        query1 = Query(query_id=0)
-        query2 = Query(query_id=1, params=[QueryParameter.number_type("num", 1)])
+        query1 = QueryBase(query_id=0)
+        query2 = QueryBase(query_id=1, params=[QueryParameter.number_type("num", 1)])
         self.assertNotEqual(hash(query1), hash(query2))
 
 

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1,7 +1,7 @@
 import datetime
 import unittest
 
-from dune_client.query import Query
+from dune_client.query import QueryBase
 from dune_client.types import QueryParameter, Address
 
 
@@ -69,14 +69,14 @@ class TestQueryParameter(unittest.TestCase):
         )
 
     def test_repr_method(self):
-        query = Query(
+        query = QueryBase(
             query_id=1,
             name="Test Query",
             params=[self.number_type, self.text_type],
         )
 
         self.assertEqual(
-            "Query(query_id=1, name='Test Query', "
+            "QueryBase(query_id=1, name='Test Query', "
             "params=["
             "Parameter(name=Number, value=1, type=number), "
             "Parameter(name=Text, value=hello, type=text)"


### PR DESCRIPTION
Dune recently added endpoints and documentation for their Queries Editing Support via the API. This PR introduces new functionality

- Create: `create_query`
- Read (Get): `get_query`
- Update `update_query`
- Delete (Archive) `archive_query`

as well as `make_private`


Unfortunately these operations require Premium membership, so I can not add tests yet.

*the the model `DuneQuery` should really make use of a real json serialization library (as well as any model implementing to/from dict), but this is a separate refactoring task.

Note that the tests failing here are related to a previous PR. #58 

cc @grkhr - I may have to revert those changes until this feature is working as expected. I tried with CURL and it was fine 

```
curl -X POST "https://api.dune.com/api/v1/query/2704703/execute" -H x-dune-api-key:${DUNE_API_KEY}  -d '{"performance": "large"}'
```


cc @grkhr